### PR TITLE
[astronomer/issues#760] Fix Airflow Grafana Dashboards

### DIFF
--- a/grafana/include/airflow-containers.json
+++ b/grafana/include/airflow-containers.json
@@ -871,7 +871,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [

--- a/grafana/include/airflow-database-activity.json
+++ b/grafana/include/airflow-database-activity.json
@@ -739,7 +739,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",

--- a/grafana/include/airflow-scheduler.json
+++ b/grafana/include/airflow-scheduler.json
@@ -1864,7 +1864,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {},
         "datasource": "Prometheus",
         "definition": "",

--- a/grafana/include/airflow-state.json
+++ b/grafana/include/airflow-state.json
@@ -1853,7 +1853,7 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": [


### PR DESCRIPTION
fixes https://github.com/astronomer/issues/issues/760

<!--
Thank you for contributing to astronomer/ap-vendor!

When you push to any branch, CI will run:
- build all images
- security scan all images

When your change is merged to master:
- build all images
- security scan all images
- any images where the version is not published to Dockerhub, then publish
-->

**Which issue this PR fixes**:
https://github.com/astronomer/issues/issues/760
<!-- if applicable, otherwise just delete the header -->

**Summary of changes**:
Airflow Dashboards weren't working as expected when we select "All", because now we have many deployments and hence the Request is very long and returns error 500 as shown below:

![image](https://user-images.githubusercontent.com/8811558/76115941-ec4cf180-5fe0-11ea-83f8-124457891a8c.png)

Setting the Custom all values: .* would help


![image](https://user-images.githubusercontent.com/8811558/76115970-fd95fe00-5fe0-11ea-9e38-7f48113b34ec.png)


![image](https://user-images.githubusercontent.com/8811558/76115976-01298500-5fe1-11ea-826d-71c3c1d8d177.png)


<!-- required -->

**Which images are updated by this PR?**:

<!-- required -->

- [ ] alertmanager
- [ ] curator
- [ ] elasticsearch-exporter
- [x] grafana
- [ ] kube-state
- [ ] nginx
- [ ] pgbouncer
- [ ] prisma
- [ ] redis
- [ ] statsd-exporter
- [ ] elasticsearch
- [ ] fluentd
- [ ] kibana
- [ ] kubed
- [ ] nginx-es
- [ ] pgbouncer-exporter
- [ ] prometheus
- [ ] node-exporter
- [ ] registry
- [ ] keda
- [ ] keda-metrics-adapter


**Additional notes for your reviewer**:
