### PR TITLE
Upgrade busybox and libuuid to resolve CVEs

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -21,4 +21,5 @@ LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 # security patches
-RUN apk upgrade busybox musl apache2 util-linux expat
+RUN apk upgrade busybox --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk upgrade musl apache2 util-linux expat libuuid


### PR DESCRIPTION

**Which issue this PR fixes**: https://github.com/astronomer/issues/issues/1159

**Summary of changes**: 

* Busybox wasn't updating, discovered solution here: 
https://unix.stackexchange.com/questions/522231/alpine-3-9-4-update-busybox-1-30-0
* libuuid also needed bumped

<!-- required -->

**Which images are updated by this PR?**:

<!-- required -->

- [ ] alertmanager
- [ ] curator
- [ ] elasticsearch-exporter
- [ ] grafana
- [ ] kube-state
- [ ] nginx
- [ ] pgbouncer
- [ ] prisma
- [ ] redis
- [ ] statsd-exporter
- [ ] elasticsearch
- [ ] fluentd
- [ ] kibana
- [ ] kubed
- [ ] nginx-es
- [ ] pgbouncer-exporter
- [ ] prometheus
- [ ] node-exporter
- [X] registry
- [ ] keda
- [ ] keda-metrics-adapter
- [ ] blackbox-exporter
- [ ] postgres-exporter

**Checklist** (required)

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [ ]  a fix has been applied OR...
- [ ]  an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

If adding a new image:

- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
- [ ] the directory includes a file "version.txt", with version matching the underlying software version
- [ ] the directory includes a file "cve-whitelist.yaml", which may be empty
- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml

**Additional notes for your reviewer**:
