### PR TITLE
Add missing statsd metrics to mappings

### DIFF
--- a/statsd-exporter/include/mappings.yml
+++ b/statsd-exporter/include/mappings.yml
@@ -6,7 +6,6 @@
 # in the case of users with many Airflow instances being monitored
 
 mappings:
-
   # Map dot separated stats to labels
   - match: airflow.operator_successes_(.*)
     match_type: regex
@@ -70,6 +69,30 @@ mappings:
     name: "airflow_pool_starving_tasks"
     labels:
       pool: "$1"
+
+  - match: airflow.zombies_killed
+    name: "airflow_zombies_killed"
+    labels: {}
+
+  - match: airflow.executor.running_tasks
+    name: "airflow_executor_running_tasks"
+    labels: {}
+
+  - match: airflow.executor.queued_tasks
+    name: "airflow_executor_queued_tasks"
+    labels: {}
+
+  - match: airflow.ti_failures
+    name: "airflow_ti_failures"
+    labels: {}
+
+  - match: airflow.ti_successes
+    name: "airflow_ti_successes"
+    labels: {}
+
+  - match: airflow.dagbag_size
+    name: "airflow_dagbag_size"
+    labels: {}
 
   # drop any metric not matched
   - match: "."


### PR DESCRIPTION
<!--
Thank you for contributing to astronomer/ap-vendor!

When you push to any branch, CI will run:
- build all images
- security scan all images

When your change is merged to main:
- build all images
- security scan all images
- any images where the version is not published to Dockerhub, then publish
-->

**Which issue this PR fixes**:

https://github.com/astronomer/issues/issues/1780

**Summary of changes**:

In the previous work to improve how/what statsd metrics are collected a handful of them were unintentionally dropped. This PR puts the specific metrics back that Houston UI and our airflow Grafana dashboard are looking for back. 

I tested this by deploying an AWS test cluster and running airflow deployments and querying for those metrics and I was getting results. 
// TODO: forgot to check Grafana, need to make sure the labels all line up correctly. 

**Which images are updated by this PR?**:

<!-- required -->

- [ ] alertmanager
- [ ] blackbox-exporter
- [ ] configmap-reloader 
- [ ] curator
- [ ] elasticsearch
- [ ] elasticsearch-exporter
- [ ] fluentd
- [ ] grafana
- [ ] keda
- [ ] keda-metrics-adapter
- [ ] kibana
- [ ] kube-state
- [ ] kubed
- [ ] nats-server
- [ ] nats-streaming
- [ ] nginx
- [ ] nginx-es
- [ ] node-exporter
- [ ] pgbouncer
- [ ] pgbouncer-exporter
- [ ] postgres-exporter
- [ ] prisma
- [ ] prometheus
- [ ] redis
- [ ] registry
- [ ] statsd-exporter

**Checklist** (required)

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [ ]  a fix has been applied OR...
- [ ]  an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

If adding a new image:

- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
- [ ] the directory includes a file "version.txt", with version matching the underlying software version
- [ ] the directory includes a file "cve-whitelist.yaml", which may be empty
- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml

**Additional notes for your reviewer**:
