### PR TITLE
Upgrade NATS Server to 2.1.8

### DIFF
--- a/nats-server/Dockerfile
+++ b/nats-server/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nats:2.1.7-alpine3.11
+FROM nats:2.1.8-alpine3.11
 
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 


### PR DESCRIPTION
**Which issue this PR fixes**:

This is PR is related to the NATS Bug: astronomer/issues#1767 

**Summary of changes**:

Upgrade from NATS Server `2.1.7` to `2.1.8`

**Which images are updated by this PR?**:

- [ ] alertmanager
- [ ] blackbox-exporter
- [ ] configmap-reloader 
- [ ] curator
- [ ] elasticsearch
- [ ] elasticsearch-exporter
- [ ] fluentd
- [ ] grafana
- [ ] keda
- [ ] keda-metrics-adapter
- [ ] kibana
- [ ] kube-state
- [ ] kubed
- [x] nats-server
- [ ] nats-streaming
- [ ] nginx
- [ ] nginx-es
- [ ] node-exporter
- [ ] pgbouncer
- [ ] pgbouncer-exporter
- [ ] postgres-exporter
- [ ] prisma
- [ ] prometheus
- [ ] redis
- [ ] registry
- [ ] statsd-exporter

**Checklist** (required)

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [x] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [ ]  a fix has been applied OR...
- [ ]  an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

**Additional notes for your reviewer**:

This fix includes some bug fixes related to NATS Network issues.  We can run in dev and test to see if this resolves the connection issues that we were experiencing with Houston API and Houston Worker dropping connections due to a STAN ping out occurring.