### PR TITLE
Create correct entrypoint files for KEDA

### DIFF
--- a/keda-metrics-apiserver/Dockerfile
+++ b/keda-metrics-apiserver/Dockerfile
@@ -20,10 +20,10 @@ ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
-ENV OPERATOR=/usr/local/bin/keda-adapter \
+ENV OPERATOR=/usr/local/bin/keda-apiserver \
     USER_UID=1001 \
     USER_NAME=keda
 
-ENTRYPOINT ["/usr/local/bin/entrypoint", "--secure-port=6443", "--logtostderr=true", "--v=0"]
+ENTRYPOINT ["/keda-adapter", "--secure-port=6443", "--logtostderr=true", "--v=0"]
 
 USER ${USER_UID}

--- a/keda/Dockerfile
+++ b/keda/Dockerfile
@@ -24,6 +24,6 @@ ENV OPERATOR=/usr/local/bin/keda \
     USER_UID=1001 \
     USER_NAME=keda
 
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
+ENTRYPOINT ["/keda"]
 
 USER ${USER_UID}


### PR DESCRIPTION
In KEDA 2.0 KEDA now has new entrypoints. This matches the entrypoints
in our image to those in the KEDA image.

https://github.com/kedacore/keda/blob/main/Dockerfile#L38
(cherry picked from commit 6f40af8812f3d10c21f4ebeb2696e771b2626064)

**Which images are updated by this PR?**:

<!-- required -->

- [ ] alertmanager
- [ ] blackbox-exporter
- [ ] configmap-reloader
- [ ] curator
- [ ] elasticsearch
- [ ] elasticsearch-exporter
- [ ] fluentd
- [ ] grafana
- [ ] keda
- [ ] keda-metrics-adapter
- [ ] kibana
- [ ] kube-state
- [ ] kubed
- [ ] nats-server
- [ ] nats-streaming
- [ ] nginx
- [ ] nginx-es
- [ ] node-exporter
- [ ] pgbouncer
- [ ] pgbouncer-exporter
- [ ] postgres-exporter
- [ ] prisma
- [ ] prometheus
- [ ] redis
- [ ] registry
- [ ] statsd-exporter

**Checklist** (required)

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)