### PR TITLE
CVE vulnerability fixes for multiple docker services

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -21,4 +21,4 @@ ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
-RUN yum -y update bind-license dbus
+RUN yum -y update bind-license dbus openssl bind-export-libs gnutls nettle

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -20,7 +20,11 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+USER root 
 
+RUN apk upgrade --no-cache libressl libressl-dev
+
+USER grafana
 # Copy default dashboards and datasource configuration
 COPY include/dashboard.yaml /etc/grafana/provisioning/dashboards/dashboard.yaml
 COPY include/nginx-ingress.json /var/lib/grafana/dashboards/nginx-ingress.json

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -20,11 +20,12 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
-USER root 
 
+# to fix openssl security issues
+USER root
 RUN apk upgrade --no-cache libressl libressl-dev
-
 USER grafana
+
 # Copy default dashboards and datasource configuration
 COPY include/dashboard.yaml /etc/grafana/provisioning/dashboards/dashboard.yaml
 COPY include/nginx-ingress.json /var/lib/grafana/dashboards/nginx-ingress.json

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -23,5 +23,5 @@ LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 # to fix bind-license security issues
 USER root
-RUN yum -y update bind-license dbus
+RUN yum -y update bind-license dbus openssl bind-export-libs gnutls nettle
 USER kibana

--- a/nats-server/Dockerfile
+++ b/nats-server/Dockerfile
@@ -20,3 +20,5 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+
+RUN apk upgrade --no-cache libressl libressl-dev

--- a/pgbouncer-exporter/Dockerfile
+++ b/pgbouncer-exporter/Dockerfile
@@ -22,6 +22,6 @@ LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 RUN set -ex \
-    && echo http://dl-cdn.alpinelinux.org/alpine/v3.7/main > /etc/apk/repositories \
-    && echo http://dl-cdn.alpinelinux.org/alpine/v3.7/community >> /etc/apk/repositories \
+    && echo http://dl-cdn.alpinelinux.org/alpine/v3.12/main >>  /etc/apk/repositories  \
+    && echo http://dl-cdn.alpinelinux.org/alpine/v3.12/community >>  /etc/apk/repositories \
     && apk upgrade --no-cache libressl libressl-dev


### PR DESCRIPTION
<!--
Thank you for contributing to astronomer/ap-vendor!

When you push to any branch, CI will run:
- build all images
- security scan all images

When your change is merged to main:
- build all images
- security scan all images
- any images where the version is not published to Dockerhub, then publish
-->

**Which issue this PR fixes**:

<!-- if applicable, otherwise just delete the header -->

**Summary of changes**:

<!-- required -->

**Which images are updated by this PR?**:

<!-- required -->

- [ ] alertmanager
- [ ] blackbox-exporter
- [ ] configmap-reloader
- [ ] curator
- [x] elasticsearch
- [ ] elasticsearch-exporter
- [ ] fluentd
- [x] grafana
- [ ] keda
- [ ] keda-metrics-apiserver
- [x] kibana
- [ ] kube-state
- [ ] kubed
- [x] nats-server
- [ ] nats-streaming
- [ ] nginx
- [ ] nginx-es
- [ ] node-exporter
- [ ] pgbouncer
- [x] pgbouncer-exporter
- [ ] postgres-exporter
- [ ] prisma
- [ ] prometheus
- [ ] redis
- [ ] registry
- [ ] statsd-exporter

**Checklist** (required)

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [x]  a fix has been applied OR...
- [ ]  an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

If adding a new image:

- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
- [ ] the directory includes a file "version.txt", with version matching the underlying software version
- [ ] the directory includes a file "cve-whitelist.yaml", which may be empty
- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml

**Additional notes for your reviewer**:
