### PR TITLE
Add back TAG env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -685,7 +685,9 @@ jobs:
       - checkout
       - run:
           name: Validate semver tag
-          command: bin/check_version.py << parameters.directory >>
+          command: |
+            version="$(bin/check_version.py << parameters.directory >>)"
+            echo "export TAG=${TAG}" >> $BASH_ENV
       - push-to-docker-hub:
           comma_separated_tags: "$TAG"
           image_name: ap-<< parameters.directory >>

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -111,7 +111,9 @@ jobs:
       - checkout
       - run:
           name: Validate semver tag
-          command: bin/check_version.py << parameters.directory >>
+          command: |
+            version="$(bin/check_version.py << parameters.directory >>)"
+            echo "export TAG=${TAG}" >> $BASH_ENV
       - push-to-docker-hub:
           comma_separated_tags: "$TAG"
           image_name: ap-<< parameters.directory >>


### PR DESCRIPTION
This logic was [mistakenly deleted](https://github.com/astronomer/ap-vendor/commit/0e7b92162a251359f902ef04d75f5978b6bd1114#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L863) when moving from in-line bash-python to external python. This env var is needed to push the version tagged docker image.