### PR TITLE
bump registry to allow override env vars for header auth

### DIFF
--- a/registry/Dockerfile
+++ b/registry/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR $DISTRIBUTION_DIR
 # this commit includes some important fixes we need to apply:  https://github.com/distribution/distribution/issues/3097 and
 # in includes fix of https://github.com/distribution/distribution/issues/625
 # since no official release since 2019 o_O
-RUN git clone https://github.com/andriisoldatenko/distribution.git $DISTRIBUTION_DIR && git checkout adde91c7d9421f80ed1199127ce66432e05446d7
+RUN git clone https://github.com/astronomer/distribution.git $DISTRIBUTION_DIR && git checkout efc278d063a4cddeff3d3b172d438a1e82375b6d
 
 RUN CGO_ENABLED=0 make PREFIX=/go clean binaries && file ./bin/registry | grep "statically linked"
 


### PR DESCRIPTION
<!--
Thank you for contributing to astronomer/ap-vendor!

When you push to any branch, CI will run:
- build all images
- security scan all images

When your change is merged to main:
- build all images
- security scan all images
- any images where the version is not published to Dockerhub, then publish
-->

## Which issue this PR fixes

<!-- if applicable, otherwise just delete the header -->

## Summary of changes

<!-- required -->

## Images are updated by this PR

<!-- required -->

- [x] registry


## Checklist

<!-- required -->

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [ ] a fix has been applied OR...
- [ ] an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

If adding a new image:

- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
- [ ] the directory includes a file "version.txt", with version matching the underlying software version
- [ ] the directory includes a file "cve-whitelist.yaml", which may be empty
- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml

## Additional notes for your reviewer
