### PR TITLE
Switch ap-fluentd base layer to Ubuntu 20.04 LTS

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:sid-slim
+FROM ubuntu:20.04
 
 ARG BUILD_NUMBER=-1
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Which issue this PR fixes

The reason is that Snyk reports the following vulnerability which has not been
fixed in any Debian version:

https://security-tracker.debian.org/tracker/CVE-2020-36327

## Summary of changes

Switch ap-fluentd base layer from Debian Sid to Ubuntu 20.04 LTS

## Images are updated by this PR

- [ ] alertmanager
- [ ] awsesproxy
- [ ] blackbox-exporter
- [ ] configmap-reloader
- [ ] curator
- [ ] dind-golang
- [ ] elasticsearch
- [ ] elasticsearch-exporter
- [x] fluentd
- [ ] git-sync
- [ ] grafana
- [ ] keda
- [ ] keda-metrics-apiserver
- [ ] kibana
- [ ] kube-state
- [ ] kubed
- [ ] nats-server
- [ ] nats-streaming
- [ ] nats-exporter
- [ ] nginx
- [ ] nginx-es
- [ ] node-exporter
- [ ] openresty
- [ ] pgbouncer
- [ ] pgbouncer-exporter
- [ ] postgresql
- [ ] postgres-exporter
- [ ] prometheus
- [ ] redis
- [ ] registry
- [ ] statsd-exporter

## Checklist

<!-- required -->

Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.

- [ ] version.txt is updated in the changed image(s)

If a security scan fails for an unchanged image...

- [ ] a fix has been applied OR...
- [ ] an [issue](<!-- link to the issue -->) has been created

<!--
Please give it a shot to fix any security issue, even if unrelated to your change.
-->

If adding a new image:

- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
- [ ] the directory includes a file "version.txt", with version matching the underlying software version
- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml

## Additional notes for your reviewer
