### PR TITLE
Upgrade all debian packages

### DIFF
--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -14,6 +14,12 @@
 
 FROM python:3.10-buster as downloader
 
+# Update packages to solve security vulnerabilities
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    rm -rf rm -rf /var/lib/apt/lists/*
+
 # https://github.com/vectordotdev/vector/releases/
 ENV VECTOR_VERSION 0.21.2
 


### PR DESCRIPTION
The current base image of vector has security vulnerabilities. This change updates all the os packages in an attempt to solve those vulnerabilities.