### PR TITLE
Remove requirement for snyk to pass before releasing image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-alertmanager
-            - scan-snyk-alertmanager
           filters:
             branches:
               only: main
@@ -82,7 +81,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-auth-sidecar
-            - scan-snyk-auth-sidecar
           filters:
             branches:
               only: main
@@ -120,7 +118,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-awsesproxy
-            - scan-snyk-awsesproxy
           filters:
             branches:
               only: main
@@ -158,7 +155,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-blackbox-exporter
-            - scan-snyk-blackbox-exporter
           filters:
             branches:
               only: main
@@ -196,7 +192,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-configmap-reloader
-            - scan-snyk-configmap-reloader
           filters:
             branches:
               only: main
@@ -234,7 +229,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-curator
-            - scan-snyk-curator
           filters:
             branches:
               only: main
@@ -272,7 +266,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-dind-golang
-            - scan-snyk-dind-golang
           filters:
             branches:
               only: main
@@ -310,7 +303,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-elasticsearch
-            - scan-snyk-elasticsearch
           filters:
             branches:
               only: main
@@ -348,7 +340,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-elasticsearch-exporter
-            - scan-snyk-elasticsearch-exporter
           filters:
             branches:
               only: main
@@ -386,7 +377,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-fluentd
-            - scan-snyk-fluentd
           filters:
             branches:
               only: main
@@ -424,7 +414,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-git-daemon
-            - scan-snyk-git-daemon
           filters:
             branches:
               only: main
@@ -462,7 +451,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-git-sync
-            - scan-snyk-git-sync
           filters:
             branches:
               only: main
@@ -500,7 +488,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-grafana
-            - scan-snyk-grafana
           filters:
             branches:
               only: main
@@ -538,7 +525,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-keda
-            - scan-snyk-keda
           filters:
             branches:
               only: main
@@ -576,7 +562,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-keda-metrics-apiserver
-            - scan-snyk-keda-metrics-apiserver
           filters:
             branches:
               only: main
@@ -614,7 +599,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-kibana
-            - scan-snyk-kibana
           filters:
             branches:
               only: main
@@ -652,7 +636,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-kube-state
-            - scan-snyk-kube-state
           filters:
             branches:
               only: main
@@ -690,7 +673,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-kubed
-            - scan-snyk-kubed
           filters:
             branches:
               only: main
@@ -728,7 +710,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-nats-exporter
-            - scan-snyk-nats-exporter
           filters:
             branches:
               only: main
@@ -766,7 +747,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-nats-server
-            - scan-snyk-nats-server
           filters:
             branches:
               only: main
@@ -804,7 +784,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-nats-streaming
-            - scan-snyk-nats-streaming
           filters:
             branches:
               only: main
@@ -842,7 +821,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-nginx
-            - scan-snyk-nginx
           filters:
             branches:
               only: main
@@ -880,7 +858,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-nginx-es
-            - scan-snyk-nginx-es
           filters:
             branches:
               only: main
@@ -918,7 +895,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-node-exporter
-            - scan-snyk-node-exporter
           filters:
             branches:
               only: main
@@ -956,7 +932,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-openresty
-            - scan-snyk-openresty
           filters:
             branches:
               only: main
@@ -994,7 +969,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-pgbouncer
-            - scan-snyk-pgbouncer
           filters:
             branches:
               only: main
@@ -1032,7 +1006,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-pgbouncer-exporter
-            - scan-snyk-pgbouncer-exporter
           filters:
             branches:
               only: main
@@ -1070,7 +1043,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-postgres-exporter
-            - scan-snyk-postgres-exporter
           filters:
             branches:
               only: main
@@ -1108,7 +1080,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-postgresql
-            - scan-snyk-postgresql
           filters:
             branches:
               only: main
@@ -1146,7 +1117,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-prometheus
-            - scan-snyk-prometheus
           filters:
             branches:
               only: main
@@ -1184,7 +1154,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-redis
-            - scan-snyk-redis
           filters:
             branches:
               only: main
@@ -1222,7 +1191,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-registry
-            - scan-snyk-registry
           filters:
             branches:
               only: main
@@ -1260,7 +1228,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-statsd-exporter
-            - scan-snyk-statsd-exporter
           filters:
             branches:
               only: main
@@ -1298,7 +1265,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-vector
-            - scan-snyk-vector
           filters:
             branches:
               only: main

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -44,7 +44,6 @@ workflows:
             - docker.io
           requires:
             - scan-trivy-{{ directory }}
-            - scan-snyk-{{ directory }}
           filters:
             branches:
               only: main


### PR DESCRIPTION
As discussed in an infra team meeting today, we are planning to deprecate snyk. It is good to have as a signal, but should not block the release. This is partly because there is no easy way like trivyignore to ignore a CVE for a single docker build.