### PR TITLE
Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,85 +1,11 @@
-<!--
-Thank you for contributing to astronomer/ap-vendor!
+## Details
 
-When you push to any branch, CI will run:
-- build all images
-- security scan all images
+Do not merge this PR until this description is replaced with relevant info about what images are being updated and what changes are being made.
 
-When your change is merged to main:
-- build all images
-- security scan all images
-- any images where the version is not published to Dockerhub, then publish
--->
+## Related Issues
 
-## Which issue this PR fixes
-
-<!-- if applicable, otherwise just delete the header -->
-
-## Summary of changes
-
-<!-- required -->
-
-## Images are updated by this PR
-
-<!-- required -->
-
-- [ ] alertmanager
-- [ ] auth-sidecar
-- [ ] awsesproxy
-- [ ] blackbox-exporter
-- [ ] configmap-reloader
-- [ ] curator
-- [ ] dind-golang
-- [ ] elasticsearch
-- [ ] elasticsearch-exporter
-- [ ] fluentd
-- [ ] git-daemon
-- [ ] git-sync
-- [ ] grafana
-- [ ] keda
-- [ ] keda-metrics-apiserver
-- [ ] kibana
-- [ ] kube-state
-- [ ] kubed
-- [ ] nats-exporter
-- [ ] nats-server
-- [ ] nats-streaming
-- [ ] nginx
-- [ ] nginx-es
-- [ ] node-exporter
-- [ ] openresty
-- [ ] pgbouncer
-- [ ] pgbouncer-exporter
-- [ ] postgres-exporter
-- [ ] postgresql
-- [ ] prometheus
-- [ ] redis
-- [ ] registry
-- [ ] statsd-exporter
-- [ ] vector
+Do not merge this PR until this text is replaced with links to related issues if one exists, or else this section is deleted.
 
 ## Checklist
 
-<!-- required -->
-
-Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.
-
-- [ ] version.txt is updated in the changed image(s)
-
-If a security scan fails for an unchanged image...
-
-- [ ] a fix has been applied OR...
-- [ ] an [issue](<!-- link to the issue -->) has been created
-
-<!--
-Please give it a shot to fix any security issue, even if unrelated to your change.
--->
-
-If adding a new image:
-
-- [ ] the directory has the same name you intend it to be published as, less a preceding "ap-"
-- [ ] the directory includes a file "version.txt", with version matching the underlying software version
-- [ ] the file .github/PULL_REQUEST_TEMPLATE.md is updated to include the image in the checklist
-- [ ] execute the script .circleci/generate_circleci_config.py, commit changes to .circleci/config.yml
-
-## Additional notes for your reviewer
+- [ ] version.txt was updated


### PR DESCRIPTION
The PR template is too long, and was rarely filled out because of that. Usually folks will replace the entire contents with something else that is more useful. This PR changes the PR template to be simpler to follow.

The full PR template is below:

## Details

Do not merge this PR until this description is replaced with relevant info about what images are being updated and what changes are being made.

## Related Issues

Do not merge this PR until this text is replaced with links to related issues if one exists, or else this section is deleted.

## Checklist

- [ ] version.txt was updated