### PR TITLE
Make 'release' require 'validate-tags'

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -202,18 +202,6 @@ workflows:
           directory: alertmanager
           requires:
             - test
-      - release:
-          directory: alertmanager
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: alertmanager
           tags: "latest"
@@ -226,6 +214,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: alertmanager
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   auth-sidecar-build:
     when:
       and:
@@ -244,18 +244,6 @@ workflows:
           directory: auth-sidecar
           requires:
             - test
-      - release:
-          directory: auth-sidecar
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: auth-sidecar
           tags: "latest"
@@ -268,6 +256,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: auth-sidecar
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   awsesproxy-build:
     when:
       and:
@@ -286,18 +286,6 @@ workflows:
           directory: awsesproxy
           requires:
             - test
-      - release:
-          directory: awsesproxy
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: awsesproxy
           tags: "latest"
@@ -310,6 +298,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: awsesproxy
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   blackbox-exporter-build:
     when:
       and:
@@ -328,18 +328,6 @@ workflows:
           directory: blackbox-exporter
           requires:
             - test
-      - release:
-          directory: blackbox-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: blackbox-exporter
           tags: "latest"
@@ -352,6 +340,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: blackbox-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   configmap-reloader-build:
     when:
       and:
@@ -370,18 +370,6 @@ workflows:
           directory: configmap-reloader
           requires:
             - test
-      - release:
-          directory: configmap-reloader
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: configmap-reloader
           tags: "latest"
@@ -394,6 +382,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: configmap-reloader
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   curator-build:
     when:
       and:
@@ -412,18 +412,6 @@ workflows:
           directory: curator
           requires:
             - test
-      - release:
-          directory: curator
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: curator
           tags: "latest"
@@ -436,6 +424,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: curator
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   dind-golang-build:
     when:
       and:
@@ -454,18 +454,6 @@ workflows:
           directory: dind-golang
           requires:
             - test
-      - release:
-          directory: dind-golang
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: dind-golang
           tags: "latest"
@@ -478,6 +466,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: dind-golang
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   dogstatsd-build:
     when:
       and:
@@ -496,18 +496,6 @@ workflows:
           directory: dogstatsd
           requires:
             - test
-      - release:
-          directory: dogstatsd
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: dogstatsd
           tags: "latest"
@@ -520,6 +508,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: dogstatsd
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   elasticsearch-build:
     when:
       and:
@@ -538,18 +538,6 @@ workflows:
           directory: elasticsearch
           requires:
             - test
-      - release:
-          directory: elasticsearch
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: elasticsearch
           tags: "latest"
@@ -562,6 +550,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: elasticsearch
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   elasticsearch-exporter-build:
     when:
       and:
@@ -580,18 +580,6 @@ workflows:
           directory: elasticsearch-exporter
           requires:
             - test
-      - release:
-          directory: elasticsearch-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: elasticsearch-exporter
           tags: "latest"
@@ -604,6 +592,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: elasticsearch-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   fluentd-build:
     when:
       and:
@@ -622,18 +622,6 @@ workflows:
           directory: fluentd
           requires:
             - test
-      - release:
-          directory: fluentd
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: fluentd
           tags: "latest"
@@ -646,6 +634,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: fluentd
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   git-daemon-build:
     when:
       and:
@@ -664,18 +664,6 @@ workflows:
           directory: git-daemon
           requires:
             - test
-      - release:
-          directory: git-daemon
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: git-daemon
           tags: "latest"
@@ -688,6 +676,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: git-daemon
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   git-sync-build:
     when:
       and:
@@ -706,18 +706,6 @@ workflows:
           directory: git-sync
           requires:
             - test
-      - release:
-          directory: git-sync
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: git-sync
           tags: "latest"
@@ -730,6 +718,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: git-sync
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   grafana-build:
     when:
       and:
@@ -748,18 +748,6 @@ workflows:
           directory: grafana
           requires:
             - test
-      - release:
-          directory: grafana
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: grafana
           tags: "latest"
@@ -772,6 +760,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: grafana
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   init-build:
     when:
       and:
@@ -790,18 +790,6 @@ workflows:
           directory: init
           requires:
             - test
-      - release:
-          directory: init
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: init
           tags: "latest"
@@ -814,6 +802,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: init
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   keda-build:
     when:
       and:
@@ -832,18 +832,6 @@ workflows:
           directory: keda
           requires:
             - test
-      - release:
-          directory: keda
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: keda
           tags: "latest"
@@ -856,6 +844,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: keda
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   keda-metrics-apiserver-build:
     when:
       and:
@@ -874,18 +874,6 @@ workflows:
           directory: keda-metrics-apiserver
           requires:
             - test
-      - release:
-          directory: keda-metrics-apiserver
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: keda-metrics-apiserver
           tags: "latest"
@@ -898,6 +886,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: keda-metrics-apiserver
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   kibana-build:
     when:
       and:
@@ -916,18 +916,6 @@ workflows:
           directory: kibana
           requires:
             - test
-      - release:
-          directory: kibana
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: kibana
           tags: "latest"
@@ -940,6 +928,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: kibana
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   kube-state-build:
     when:
       and:
@@ -958,18 +958,6 @@ workflows:
           directory: kube-state
           requires:
             - test
-      - release:
-          directory: kube-state
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: kube-state
           tags: "latest"
@@ -982,6 +970,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: kube-state
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   kubed-build:
     when:
       and:
@@ -1000,18 +1000,6 @@ workflows:
           directory: kubed
           requires:
             - test
-      - release:
-          directory: kubed
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: kubed
           tags: "latest"
@@ -1024,6 +1012,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: kubed
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   nats-exporter-build:
     when:
       and:
@@ -1042,18 +1042,6 @@ workflows:
           directory: nats-exporter
           requires:
             - test
-      - release:
-          directory: nats-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: nats-exporter
           tags: "latest"
@@ -1066,6 +1054,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: nats-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   nats-server-build:
     when:
       and:
@@ -1084,18 +1084,6 @@ workflows:
           directory: nats-server
           requires:
             - test
-      - release:
-          directory: nats-server
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: nats-server
           tags: "latest"
@@ -1108,6 +1096,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: nats-server
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   nats-streaming-build:
     when:
       and:
@@ -1126,18 +1126,6 @@ workflows:
           directory: nats-streaming
           requires:
             - test
-      - release:
-          directory: nats-streaming
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: nats-streaming
           tags: "latest"
@@ -1150,6 +1138,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: nats-streaming
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   nginx-build:
     when:
       and:
@@ -1168,18 +1168,6 @@ workflows:
           directory: nginx
           requires:
             - test
-      - release:
-          directory: nginx
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: nginx
           tags: "latest"
@@ -1192,6 +1180,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: nginx
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   nginx-es-build:
     when:
       and:
@@ -1210,18 +1210,6 @@ workflows:
           directory: nginx-es
           requires:
             - test
-      - release:
-          directory: nginx-es
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: nginx-es
           tags: "latest"
@@ -1234,6 +1222,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: nginx-es
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   node-exporter-build:
     when:
       and:
@@ -1252,18 +1252,6 @@ workflows:
           directory: node-exporter
           requires:
             - test
-      - release:
-          directory: node-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: node-exporter
           tags: "latest"
@@ -1276,6 +1264,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: node-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   openresty-build:
     when:
       and:
@@ -1294,18 +1294,6 @@ workflows:
           directory: openresty
           requires:
             - test
-      - release:
-          directory: openresty
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: openresty
           tags: "latest"
@@ -1318,6 +1306,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: openresty
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   pgbouncer-build:
     when:
       and:
@@ -1336,18 +1336,6 @@ workflows:
           directory: pgbouncer
           requires:
             - test
-      - release:
-          directory: pgbouncer
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: pgbouncer
           tags: "latest"
@@ -1360,6 +1348,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: pgbouncer
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   pgbouncer-exporter-build:
     when:
       and:
@@ -1378,18 +1378,6 @@ workflows:
           directory: pgbouncer-exporter
           requires:
             - test
-      - release:
-          directory: pgbouncer-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: pgbouncer-exporter
           tags: "latest"
@@ -1402,6 +1390,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: pgbouncer-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   pgbouncer-krb-build:
     when:
       and:
@@ -1420,18 +1420,6 @@ workflows:
           directory: pgbouncer-krb
           requires:
             - test
-      - release:
-          directory: pgbouncer-krb
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: pgbouncer-krb
           tags: "latest"
@@ -1444,6 +1432,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: pgbouncer-krb
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   po-logical-backup-build:
     when:
       and:
@@ -1462,18 +1462,6 @@ workflows:
           directory: po-logical-backup
           requires:
             - test
-      - release:
-          directory: po-logical-backup
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: po-logical-backup
           tags: "latest"
@@ -1486,6 +1474,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: po-logical-backup
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   po-pgbouncer-build:
     when:
       and:
@@ -1504,18 +1504,6 @@ workflows:
           directory: po-pgbouncer
           requires:
             - test
-      - release:
-          directory: po-pgbouncer
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: po-pgbouncer
           tags: "latest"
@@ -1528,6 +1516,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: po-pgbouncer
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   po-spilo-build:
     when:
       and:
@@ -1546,18 +1546,6 @@ workflows:
           directory: po-spilo
           requires:
             - test
-      - release:
-          directory: po-spilo
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: po-spilo
           tags: "latest"
@@ -1570,6 +1558,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: po-spilo
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   postgres-exporter-build:
     when:
       and:
@@ -1588,18 +1588,6 @@ workflows:
           directory: postgres-exporter
           requires:
             - test
-      - release:
-          directory: postgres-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: postgres-exporter
           tags: "latest"
@@ -1612,6 +1600,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: postgres-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   postgres-operator-build:
     when:
       and:
@@ -1630,18 +1630,6 @@ workflows:
           directory: postgres-operator
           requires:
             - test
-      - release:
-          directory: postgres-operator
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: postgres-operator
           tags: "latest"
@@ -1654,6 +1642,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: postgres-operator
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   postgresql-build:
     when:
       and:
@@ -1672,18 +1672,6 @@ workflows:
           directory: postgresql
           requires:
             - test
-      - release:
-          directory: postgresql
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: postgresql
           tags: "latest"
@@ -1696,6 +1684,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: postgresql
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   prometheus-build:
     when:
       and:
@@ -1714,18 +1714,6 @@ workflows:
           directory: prometheus
           requires:
             - test
-      - release:
-          directory: prometheus
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: prometheus
           tags: "latest"
@@ -1738,6 +1726,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: prometheus
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   redis-build:
     when:
       and:
@@ -1756,18 +1756,6 @@ workflows:
           directory: redis
           requires:
             - test
-      - release:
-          directory: redis
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: redis
           tags: "latest"
@@ -1780,6 +1768,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: redis
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   registry-build:
     when:
       and:
@@ -1798,18 +1798,6 @@ workflows:
           directory: registry
           requires:
             - test
-      - release:
-          directory: registry
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: registry
           tags: "latest"
@@ -1822,6 +1810,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: registry
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   statsd-exporter-build:
     when:
       and:
@@ -1840,18 +1840,6 @@ workflows:
           directory: statsd-exporter
           requires:
             - test
-      - release:
-          directory: statsd-exporter
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: statsd-exporter
           tags: "latest"
@@ -1864,6 +1852,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: statsd-exporter
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
   vector-build:
     when:
       and:
@@ -1882,18 +1882,6 @@ workflows:
           directory: vector
           requires:
             - test
-      - release:
-          directory: vector
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: vector
           tags: "latest"
@@ -1906,6 +1894,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: vector
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
 
 jobs:
   build:

--- a/.circleci/continue-config.yml.j2
+++ b/.circleci/continue-config.yml.j2
@@ -43,18 +43,6 @@ workflows:
           directory: {{ directory }}
           requires:
             - test
-      - release:
-          directory: {{ directory }}
-          tags: "latest"
-          overwrite_tags: << pipeline.parameters.overwrite_tags >>
-          context:
-            - quay.io
-            - docker.io
-          requires:
-            - scan-trivy
-          filters:
-            branches:
-              only: main
       - validate-tags:
           directory: {{ directory }}
           tags: "latest"
@@ -67,6 +55,18 @@ workflows:
           filters:
             branches:
               ignore: main
+      - release:
+          directory: {{ directory }}
+          tags: "latest"
+          overwrite_tags: << pipeline.parameters.overwrite_tags >>
+          context:
+            - quay.io
+            - docker.io
+          requires:
+            - validate-tags
+          filters:
+            branches:
+              only: main
 {%- endfor %}
 
 jobs:


### PR DESCRIPTION
## Details

Make 'release' require 'validate-tags'.

The current flow looks like this:

<img width="1007" alt="Screenshot 2023-04-07 at 6 28 30 PM" src="https://user-images.githubusercontent.com/1323808/230686554-02d1e04c-f46a-4cdd-9056-eade9e3398c4.png">

After merging these changes, "validate-tags" must pass before "release" can run.

## Related Issues

N/A