### PR TITLE
[Software Bot]update curator service with version upstream_version

### DIFF
--- a/curator/Dockerfile
+++ b/curator/Dockerfile
@@ -22,7 +22,7 @@ LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 # https://github.com/elastic/curator/releases
-ENV CURATOR_VERSION 8.0.9
+ENV CURATOR_VERSION upstream_version
 
 RUN set -x ; apk --no-cache add \
       libffi \

--- a/curator/version.txt
+++ b/curator/version.txt
@@ -1,1 +1,1 @@
-8.0.9
+upstream_version


### PR DESCRIPTION
**** This is an auto generated Pull Request ****
This PR updates  curator service with version upstream_version.


Link to Release Notes : https://github.com/elastic/curator/releases/tag/v8.0.10


## Related Issues

if relevant, please link to the issue here

## Checklist

- [x] version.txt was updated