### PR TITLE
Push images to both public and private ACR instances

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -2574,6 +2574,16 @@ jobs:
           image_name: ap-<< parameters.directory >>
           tags: << parameters.tags >>
           overwrite_tags: << parameters.overwrite_tags >>
+      - docker-operations:
+          operations: push
+          project_path: << parameters.directory >>
+          registry: "astrocr.azurecr.io"
+          registry_username: "${ACR_USERNAME}"
+          registry_password: "${ACR_PASSWORD}"
+          repository: "astronomer"
+          image_name: ap-<< parameters.directory >>
+          tags: << parameters.tags >>
+          overwrite_tags: << parameters.overwrite_tags >>
 
   validate-tags:
     executor: docker-executor
@@ -2627,6 +2637,16 @@ jobs:
           registry: "astrocrpublic.azurecr.io"
           registry_username: "${ACR_PUBLIC_USERNAME}"
           registry_password: "${ACR_PUBLIC_PASSWORD}"
+          repository: "astronomer"
+          image_name: ap-<< parameters.directory >>
+          tags: << parameters.tags >>
+          overwrite_tags: << parameters.overwrite_tags >>
+      - docker-operations:
+          operations: validate_tags
+          project_path: << parameters.directory >>
+          registry: "astrocr.azurecr.io"
+          registry_username: "${ACR_USERNAME}"
+          registry_password: "${ACR_PASSWORD}"
           repository: "astronomer"
           image_name: ap-<< parameters.directory >>
           tags: << parameters.tags >>

--- a/.circleci/continue-config.yml.j2
+++ b/.circleci/continue-config.yml.j2
@@ -239,6 +239,16 @@ jobs:
           image_name: ap-<< parameters.directory >>
           tags: << parameters.tags >>
           overwrite_tags: << parameters.overwrite_tags >>
+      - docker-operations:
+          operations: push
+          project_path: << parameters.directory >>
+          registry: "astrocr.azurecr.io"
+          registry_username: "${ACR_USERNAME}"
+          registry_password: "${ACR_PASSWORD}"
+          repository: "astronomer"
+          image_name: ap-<< parameters.directory >>
+          tags: << parameters.tags >>
+          overwrite_tags: << parameters.overwrite_tags >>
 
   validate-tags:
     executor: docker-executor
@@ -292,6 +302,16 @@ jobs:
           registry: "astrocrpublic.azurecr.io"
           registry_username: "${ACR_PUBLIC_USERNAME}"
           registry_password: "${ACR_PUBLIC_PASSWORD}"
+          repository: "astronomer"
+          image_name: ap-<< parameters.directory >>
+          tags: << parameters.tags >>
+          overwrite_tags: << parameters.overwrite_tags >>
+      - docker-operations:
+          operations: validate_tags
+          project_path: << parameters.directory >>
+          registry: "astrocr.azurecr.io"
+          registry_username: "${ACR_USERNAME}"
+          registry_password: "${ACR_PASSWORD}"
           repository: "astronomer"
           image_name: ap-<< parameters.directory >>
           tags: << parameters.tags >>


### PR DESCRIPTION
This is a partial revert of https://github.com/astronomer/ap-vendor/pull/750

The registry cache in Astro data planes may pull images from our private ACR instance, `astrocr.azurecr.io`. The linked `ap-vendor` PR changed the destination in ACR for images from the repository to the public registry because they need to be accessible to users who run Astronomer software on-premises, but this also made new image tags inaccessible to hosted data planes if they pull from ACR.

ACR offers pull through caching as a feature, but as per discussion in https://github.com/Azure/acr/issues/599 it does not currently support using ACR itself as a target for a pull-through cache. Since we cannot configure the private registry to pull images from the public registry, the next best option to make all images (public and private) accessible is to push the public images to both registries.