### PR TITLE
Pin trivy to 0.53.0

### DIFF
--- a/.circleci/continue-config.yml
+++ b/.circleci/continue-config.yml
@@ -2471,7 +2471,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.53.0
             date +%F > date
       - restore_cache:
           keys:

--- a/.circleci/continue-config.yml.j2
+++ b/.circleci/continue-config.yml.j2
@@ -136,7 +136,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.53.0
             date +%F > date
       - restore_cache:
           keys:


### PR DESCRIPTION
## Details

Pin trivy to 0.53.0 because they keep breaking the CLI, and it looks like the current version has bugs that prevent it from working entirely. `trvy -c filename` should run with the given config, but it does not appear to work. Also, the help text says `trivy --generate-default-config` should exist, but it appears to not do what it should.

The easiest way to fix the problem in this repo is to pin to 0.53.0, which I have verified does work. Other repos have other syntax errors and may need to pin to 0.52.2 EG: https://github.com/astronomer/astro-ui/blob/06f175860/.circleci/config.yml#L243

## Related Issues

https://github.com/astronomer/issues/issues/6534