### PR TITLE
Add a bunch of license data

### DIFF
--- a/alertmanager/metadata.yaml
+++ b/alertmanager/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus/alertmanager/blob/main/LICENSE

--- a/auth-sidecar/metadata.yaml
+++ b/auth-sidecar/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: "Nginx: BSD-2-Clause License"
+  url: https://nginx.org/LICENSE

--- a/awsesproxy/metadata.yaml
+++ b/awsesproxy/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/abutaha/aws-es-proxy/blob/master/LICENSE

--- a/blackbox-exporter/metadata.yaml
+++ b/blackbox-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus/blackbox_exporter/blob/master/LICENSE

--- a/configmap-reloader/metadata.yaml
+++ b/configmap-reloader/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/jimmidyson/configmap-reload/blob/main/LICENSE.txt

--- a/curator/metadata.yaml
+++ b/curator/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/elastic/curator/blob/master/LICENSE

--- a/dogstatsd/metadata.yaml
+++ b/dogstatsd/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Simplified BSD License
+  url: https://github.com/DataDog/dd-agent/blob/master/LICENSE

--- a/elasticsearch-exporter/metadata.yaml
+++ b/elasticsearch-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus-community/elasticsearch_exporter/blob/master/LICENSE

--- a/elasticsearch/metadata.yaml
+++ b/elasticsearch/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Elastic License 2.0
+  url: https://github.com/elastic/elasticsearch/blob/main/LICENSE.txt

--- a/fluentd/metadata.yaml
+++ b/fluentd/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/fluent/fluentd/blob/master/LICENSE

--- a/grafana/metadata.yaml
+++ b/grafana/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: AGPLv3
+  url: https://github.com/grafana/grafana/blob/main/LICENSE

--- a/keda-metrics-apiserver/metadata.yaml
+++ b/keda-metrics-apiserver/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/kedacore/keda/blob/main/LICENSE

--- a/keda/metadata.yaml
+++ b/keda/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/kedacore/keda/blob/main/LICENSE

--- a/kibana/metadata.yaml
+++ b/kibana/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Elastic License 2.0
+  url: https://github.com/elastic/elasticsearch/blob/main/LICENSE.txt

--- a/kube-state/metadata.yaml
+++ b/kube-state/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/kubernetes/kube-state-metrics/blob/main/LICENSE

--- a/nats-exporter/metadata.yaml
+++ b/nats-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/nats-io/prometheus-nats-exporter/blob/main/LICENSE

--- a/nats-server/metadata.yaml
+++ b/nats-server/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/nats-io/nats-server/blob/main/LICENSE

--- a/nats-streaming/metadata.yaml
+++ b/nats-streaming/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/nats-io/nats-streaming-server/blob/main/LICENSE

--- a/nginx-es/metadata.yaml
+++ b/nginx-es/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: "Nginx: BSD-2-Clause License"
+  url: https://nginx.org/LICENSE

--- a/nginx/metadata.yaml
+++ b/nginx/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: "Nginx: BSD-2-Clause License"
+  url: https://nginx.org/LICENSE

--- a/node-exporter/metadata.yaml
+++ b/node-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus/node_exporter/blob/master/LICENSE

--- a/openresty/metadata.yaml
+++ b/openresty/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: various
+  url: https://github.com/openresty/openresty/blob/master/COPYRIGHT

--- a/pgbouncer-exporter/metadata.yaml
+++ b/pgbouncer-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: MIT
+  url: https://github.com/prometheus-community/pgbouncer_exporter/blob/master/LICENSE

--- a/pgbouncer/metadata.yaml
+++ b/pgbouncer/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: MIT
+  url: https://github.com/pgbouncer/pg_pgbouncer/blob/main/LICENSE

--- a/postgres-exporter/metadata.yaml
+++ b/postgres-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus-community/postgres_exporter/blob/master/LICENSE

--- a/postgres-operator/metadata.yaml
+++ b/postgres-operator/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: MIT
+  url: https://github.com/zalando/postgres-operator/blob/master/LICENSE

--- a/postgresql/metadata.yaml
+++ b/postgresql/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: PostgreSQL License
+  url: https://www.postgresql.org/about/licence/

--- a/prometheus/metadata.yaml
+++ b/prometheus/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: Apache 2.0
+  url: https://github.com/prometheus/prometheus/blob/main/LICENSE

--- a/python/metadata.yaml
+++ b/python/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+  url: https://github.com/python/cpython/blob/main/LICENSE

--- a/redis/metadata.yaml
+++ b/redis/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: SSPL, RSALv2
+  url: https://github.com/redis/redis/blob/unstable/LICENSE.txt

--- a/registry/metadata.yaml
+++ b/registry/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  link: https://github.com/distribution/distribution/blob/main/LICENSE
+  name: Apache 2.0

--- a/statsd-exporter/metadata.yaml
+++ b/statsd-exporter/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  link: https://github.com/prometheus/statsd_exporter/blob/master/LICENSE
+  name: Apache 2.0

--- a/vector/metadata.yaml
+++ b/vector/metadata.yaml
@@ -1,0 +1,3 @@
+license:
+  name: MPL 2.0
+  url: https://github.com/vectordotdev/vector/blob/master/LICENSE


### PR DESCRIPTION
## Details

Add a bunch of data about our licenses. This introduces a `metadata.yaml` file for each build directory. Not all build directories are included in this PR because only the licenses are being populated into the files, and not all licensing information is known.

## Related Issues

https://github.com/astronomer/issues/issues/6983