### PR TITLE
APC-1353: Add go stage in git-sync

### DIFF
--- a/git-sync/Dockerfile
+++ b/git-sync/Dockerfile
@@ -28,30 +28,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # https://github.com/kubernetes/git-sync/releases
-FROM quay.io/astronomer/ap-base:2026.5.22
-LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-USER root
-
-# Install git and openssh-client (Go 1.25.1 is already installed)
-RUN apk update && apk upgrade --available && \
-    apk add --no-cache openssh-client git
-
-# Build git-sync from source with Go 1.25.1
+FROM golang:1.26.3-alpine3.22 AS builder
+RUN apk add --no-cache git
 RUN git clone https://github.com/kubernetes/git-sync.git /tmp/git-sync && \
     cd /tmp/git-sync && \
     git checkout v4.4.1 && \
     CGO_ENABLED=0 go build -o /usr/local/bin/git-sync . && \
     cd / && rm -rf /tmp/git-sync
 
+FROM quay.io/astronomer/ap-base:2026.5.22
+LABEL maintainer="Astronomer <humans@astronomer.io>"
+USER root
+RUN apk update && apk upgrade --available && \
+    apk add --no-cache openssh-client git
+COPY --from=builder /usr/local/bin/git-sync /usr/local/bin/git-sync
 RUN echo "git-sync:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd
 RUN mkdir -m 02775 /git && chown 65533:65533 /git
-
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
-
 RUN git config --global --add safe.directory /git
-
 USER 65533
 ENTRYPOINT  [ "git-sync" ]


### PR DESCRIPTION
## Details

This PR adds Go build step in git-sync as this was removed due to ongoing effort of reducing CVEs from ap-base.

## Related Issues

https://linear.app/astronomer/issue/APC-1353

## Checklist

- [x] version.txt was updated
