### PR TITLE
Reruns alertmanager, awsesproxy, blackbox

### DIFF
--- a/alertmanager/Dockerfile
+++ b/alertmanager/Dockerfile
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 # https://console.chainguard.dev/org/astronomer.io/images/organization/image/prometheus-alertmanager
 FROM cgr.dev/astronomer.io/prometheus-alertmanager:0.32.1 AS upstream
 

--- a/awsesproxy/Dockerfile
+++ b/awsesproxy/Dockerfile
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 ARG GO_VERSION=1.26.3
 FROM golang:${GO_VERSION}-alpine AS builder
 

--- a/blackbox-exporter/Dockerfile
+++ b/blackbox-exporter/Dockerfile
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 # https://hub.docker.com/_/golang/tags?name=1.22-alpine
+
 FROM golang:1.26.3-alpine3.22 AS build
 
 ENV DISTRIBUTION_DIR=/go/src/github.com/prometheus/blackbox_exporter


### PR DESCRIPTION
## Details

This just re-runs few pipelines that failed to run due to endorlab dependency that was introduced but is currently blocked


## Checklist

- [x] version.txt was updated
