### PR TITLE
Add endor ignore file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
   run_pre_commit:
     resource_class: small
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-05
+      - image: quay.io/astronomer/ci-pre-commit:2026-06
     steps:
       - checkout
       - run:


### PR DESCRIPTION
## Details

PR adds endor ignore file to ES and re-triggeres ES as it seems the build failed due to old ci image in the run. 



## Checklist

- [x] version.txt was updated. -- N/A since this tag was not released. 
